### PR TITLE
se arregla el coloreado de las comillas y se agrega la palabra clave osi

### DIFF
--- a/LATINO.YAML-tmLanguage
+++ b/LATINO.YAML-tmLanguage
@@ -30,18 +30,10 @@ patterns:
     "1": {name: comment.block.end.lat }
 
 - comment: Comillas 
-  name: string.quoted.double.lat
-  begin: '"'
-  end: '"'
+  name: string.quoted.lat
+  match: '([\'\"])(?:(?!\1|\\).|\\.)*\1'
   captures:
-    '1': {name: string.quoted.double.lat}
-
-- comment: Comillas 
-  name: string.quoted.single.lat
-  begin: "'"
-  end: "'"
-  captures:
-    '1': {name: string.quoted.single.lat}
+    '1': {name: string.quoted.lat}
 
 #                   INICIO CONSTANTES
 - comment: Constantes 
@@ -65,7 +57,7 @@ patterns:
 #                   INICIO SENTENCIAS DE CONTROL
 - comment: Sentencias de control
   name: keyword.control.lat
-  match: '\b(si|sino|fin|mientras|desde|hasta|elegir|caso|defecto|hacer|cuando|retorno|defecto)\b'
+  match: '\b(si|osi|sino|fin|mientras|desde|hasta|elegir|caso|defecto|hacer|cuando|retorno|defecto)\b'
   captures:
     '1': {name: keyword.control.lat}
 

--- a/LATINO.tmLanguage
+++ b/LATINO.tmLanguage
@@ -61,40 +61,20 @@
 			<string>comment.block.end.latino</string>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>"</string>
 			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>string.quoted.double.lat</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Comillas</string>
-			<key>end</key>
-			<string>"</string>
-			<key>name</key>
-			<string>string.quoted.double.lat</string>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>'</string>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>string.quoted.single.lat</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Comillas</string>
-			<key>end</key>
-			<string>'</string>
-			<key>name</key>
-			<string>string.quoted.single.lat</string>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>string.quoted.lat</string>
+                </dict>
+            </dict>
+            <key>comment</key>
+            <string>Comillas</string>
+            <key>match</key>
+            <string>(['"])(?:(?!\1|\\).|\\.)*\1</string>
+            <key>name</key>
+            <string>string.quoted.lat</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -156,7 +136,7 @@
 			<key>comment</key>
 			<string>Sentencias de control</string>
 			<key>match</key>
-			<string>\b(si|sino|fin|mientras|desde|hasta|elegir|caso|defecto|hacer|cuando|retorno|defecto)\b</string>
+			<string>\b(si|osi|sino|fin|mientras|desde|hasta|elegir|caso|defecto|hacer|cuando|retorno|defecto)\b</string>
 			<key>name</key>
 			<string>keyword.control.lat</string>
 		</dict>


### PR DESCRIPTION
Había un inconveniente con el coloreado de las comillas que no detectaba el escapado lo cual ocasionaba que el código que se encontrará más adelante no se coloreara de forma correcta.

![imagen1](https://user-images.githubusercontent.com/109115234/178377209-2b23c149-1081-4d44-b82f-1d9d89c10f0d.png)

Y el problema se podía resolver poniendo un comentario con su respectivo signo, pero no tiene sentido hacer eso por un problema visual.

![imagen2](https://user-images.githubusercontent.com/109115234/178377371-f88c6939-c301-4247-88c7-febdd20448f0.png)

Y con la solución que doy, ya no pasa esto y tampoco es necesario utilizar comentarios.

![imagen3](https://user-images.githubusercontent.com/109115234/178377599-ad0c7337-7a7d-41d7-9a90-93d3c63f6f75.png)

Y de camino agregué una palabra clave que vi que faltaba.

